### PR TITLE
Add support for two features: Obsidian Wiki Links with anchors, and handling files in subdirectories during link generation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ function action(data) {
           // For links with anchor, use direct HTML link to preserve anchor
           content = content.replace(
             linkName,
-            `<a href="../${file.articleName}#${anchor}">${showName || realName}</a>`,
+            `<a href="../${file.articleName}#${anchor}">${showName || realName} > ${anchor}</a>`,
           );
         } else {
           // For regular links, use post_link tag

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,9 +91,11 @@ function action(data) {
         // If the target article was found. then replace the backlink with 'post_link'
         if (anchor) {
           // For links with anchor, use direct HTML link to preserve anchor
+          // Replace underscores, dots and spaces with hyphens in anchor
+          const formattedAnchor = anchor.replace(/[_\. ]/g, '-');
           content = content.replace(
             linkName,
-            `<a href="/${file.articleName}#${anchor}">${showName || realName.replace(/^(\.\.\/)+/, '').replace(/^\.\//, '')} > ${anchor}</a>`,
+            `<a href="/${file.articleName}#${formattedAnchor}">${showName || realName.replace(/^(\.\.\/)+/, '').replace(/^\.\//, '')} > ${anchor}</a>`,
           );
         } else {
           // For regular links, use post_link tag

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,23 +7,61 @@ import path from "path";
 
 const base_dir = path.join(hexo.source_dir, "_posts");
 
+/**
+ * Process the file path and generate standardized file information
+ * @param each File path
+ * @returns Object containing file information
+ */
+function processFilePath(each) {
+  // Handle Windows path separators
+  if (path.sep === "\\") {
+    each = each.replace(new RegExp("\\" + path.sep, "g"), "/");
+  }
+  
+  // Split path into components
+  const array = each.split("/");
+  const fileNameExt = array.length === 0 ? "" : array[array.length - 1];
+  const articleName = each.replace(/\.md$/, "");
+  
+  return {
+    fileNameExt,
+    filePath: each,
+    articleName,
+    fullPath: each
+  };
+}
+
+/**
+ * Find a file by its full path or file name
+ * @param realNameExt File name with extension or full path
+ * @returns The found file object or undefined
+ */
+function findFile(realNameExt: string) {
+  // Process relative paths, converting them to normalized paths
+  let normalizedPath = realNameExt.replace(/^\.\//, '');
+  // Remove all ../ prefixes
+  while (normalizedPath.startsWith('../')) {
+    normalizedPath = normalizedPath.substring(3);
+  }
+
+  // First try to find by normalized path
+  let file = fileList.find((file) => file.filePath === normalizedPath);
+  if (file) return file;
+  
+  // If not found, try by full path
+  file = fileList.find((file) => file.filePath === realNameExt);
+  if (file) return file;
+  
+  // If not found, try by file name
+  return fileList.find((file) => file.fileNameExt === realNameExt);
+}
+
 const fileList = fs
   .listDirSync(base_dir, {
     ignorePattern: /node_modules/,
   })
   .filter((each) => each && /\.md$/.test(each))
-  .map((each) => {
-    let array = (each + "").split(path.sep);
-    // For Windows
-    if (path.sep === "\\") {
-      each = each.replace(new RegExp("\\" + path.sep, "g"), "/");
-    }
-    return {
-      fileNameExt: array.length === 0 ? "" : array[array.length - 1],
-      filePath: each,
-      articleName: each.replace(/\.md$/, ""),
-    };
-  });
+  .map(processFilePath);
 
 /**
  * md returns true
@@ -32,7 +70,7 @@ const fileList = fs
 const ignore = (data) => {
   const source = data.source;
   const ext = source.substring(source.lastIndexOf(".")).toLowerCase();
-  return ["md"].indexOf(ext) > -1;
+  return ext !== ".md";
 };
 
 function action(data) {
@@ -40,22 +78,22 @@ function action(data) {
   let result = content.match(/\[\[.*?]]/g);
   if (result && result.length > 0) {
     result.forEach((linkName: string) => {
-      // {% post_link Ubuntu/ubuntu-enable-root 'Ubuntu Linux上启用root账户' %}
       let [realName, showName] = (linkName + "")
         .replace("[[", "")
         .replace("]]", "")
         .split("|");
       let anchor = null;
       [realName, anchor] = realName.split("#");
-      let realNameExt = realName + ".md";
-      let file = fileList.find((file) => file.fileNameExt === realNameExt);
+      // Check if realName already has .md extension
+      let realNameExt = realName.endsWith(".md") ? realName : realName + ".md";
+      let file = findFile(realNameExt);
       if (file) {
         // If the target article was found. then replace the backlink with 'post_link'
         if (anchor) {
           // For links with anchor, use direct HTML link to preserve anchor
           content = content.replace(
             linkName,
-            `<a href="../${file.articleName}#${anchor}">${showName || realName} > ${anchor}</a>`,
+            `<a href="/${file.articleName}#${anchor}">${showName || realName.replace(/^(\.\.\/)+/, '').replace(/^\.\//, '')} > ${anchor}</a>`,
           );
         } else {
           // For regular links, use post_link tag

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,13 +51,19 @@ function action(data) {
       let file = fileList.find((file) => file.fileNameExt === realNameExt);
       if (file) {
         // If the target article was found. then replace the backlink with 'post_link'
-        content = content.replace(
-          linkName,
-          // `<a href="${file.articleName}${
-          //   anchor ? "#" + anchor : ""
-          // }" name="${realName}" id="huiqu">${showName || realName}</a>`
-          `{% post_link ${file.articleName} '${showName || realName}' %}`,
-        );
+        if (anchor) {
+          // For links with anchor, use direct HTML link to preserve anchor
+          content = content.replace(
+            linkName,
+            `<a href="../${file.articleName}#${anchor}">${showName || realName}</a>`,
+          );
+        } else {
+          // For regular links, use post_link tag
+          content = content.replace(
+            linkName,
+            `{% post_link ${file.articleName} '${showName || realName}' %}`,
+          );
+        }
       }
     });
   }


### PR DESCRIPTION
### New Features
**Enhanced Obsidian Wiki Link Support**:
- Convert Obsidian wiki links with anchors (`[[title#subtitle]]`) to static web links with anchors
- Support handling files in subdirectories during link generation, ensuring correct link paths for files stored in nested folders


### Testing steps
   - Replace the content of the file "(Blog Directory)\node_modules\hexo-backlink\index.js" with the changed content of the corresponding index.ts file
   - Create test posts with both regular and anchor wiki links
   - Run `hexo clean && hexo generate`
   - Run `hexo s -s`
   - Inspect generated HTML for correct link formats
   - Test navigation to regular wiki links to confirm they work as expected
   - Test navigation to anchor wiki links (e.g., [[../Adir/a#title]] in b.md) to verify anchor jumping is accurate
   - Test navigation to cross-subdirectory links (e.g., [[../Bdir/b]] in a.md) to ensure subdirectory path resolution is correct
   - If all links work perfectly? Voila🎉! Time to celebrate your link magic~

### Known Issue (Requires Hexo Config Change, Unfixable via Plugin Modifications)
https://github.com/Zhaosn/hexo-backlink/issues/2

### bug fixed
https://github.com/Zhaosn/hexo-backlink/issues/1

### Note
Due to my unfamiliarity with the `npm run build` command (and the files generated by this command are excessively large), I directly replacing the file content instead of the standard build process.